### PR TITLE
make Browser obey redirects from <meta> tags which are immediate chil…

### DIFF
--- a/src/main/scala/net/ruippeixotog/scalascraper/browser/Browser.scala
+++ b/src/main/scala/net/ruippeixotog/scalascraper/browser/Browser.scala
@@ -47,7 +47,7 @@ class Browser {
 
     val redirectUrl =
       if (res.hasHeader("Location")) Some(res.header("Location"))
-      else doc.select("head meta[http-equiv=refresh]").headOption.flatMap { e =>
+      else doc.select("head > meta[http-equiv=refresh]").headOption.flatMap { e =>
         e.attr("content") match {
           case QuotedMetaRefreshUrl(url) => Some(url)
           case MetaRefreshUrl(url) => Some(url)

--- a/src/test/scala/net/ruippeixotog/scalascraper/browser/BrowserSpec.scala
+++ b/src/test/scala/net/ruippeixotog/scalascraper/browser/BrowserSpec.scala
@@ -115,6 +115,17 @@ class BrowserSpec extends Specification {
       browser.get("http://example.com/original").body.attr("id") mustEqual "bid"
     }
 
+    "ignore redirects in meta refresh HTML tags inside noscripts" in {
+      val browser = new MockBrowser()
+      val redirectHtml =
+        """<head><noscript><meta http-equiv="refresh" content="0;URL='http://example.com/redirected'" /></noscript></head><body id='orig'></body>"""
+
+      browser.addMockResponse(MockResponse("http://example.com/original", body = redirectHtml))
+      browser.addMockResponse(MockResponse("http://example.com/redirected", body = html))
+
+      browser.get("http://example.com/original").body.attr("id") mustEqual "orig"
+    }
+
     "keep and use cookies between requests" in {
       val browser = new MockBrowser()
 


### PR DESCRIPTION
Hello, this patch solves my problem with VK. I'm not sure though, is it correct to ignore meta that way. Probably it depends on the policy concerning noscript. I guess scraper should pretend to be a regular user-client to be usable.