### PR TITLE
Add directories to travis' cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ scala:
   - 2.11.7
 jdk:
   - oraclejdk8
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot


### PR DESCRIPTION
This PR adds ivy2's `cache` and sbt's `.boot` directories to travis' cache.