### PR TITLE
Added localized date time parsers (fixes #65).

### DIFF
--- a/core/src/main/scala/net/ruippeixotog/scalascraper/scraper/ContentParsers.scala
+++ b/core/src/main/scala/net/ruippeixotog/scalascraper/scraper/ContentParsers.scala
@@ -110,6 +110,15 @@ object ContentParsers {
       *   a content parser for parsing text content as a `DateTime` using `tz` as default time zone.
       */
     def withZone(tz: DateTimeZone): String => DateTime = formatter.withZone(tz).parseDateTime(_).withZone(tz)
+
+    /** Parses text content as a `DateTime` using a provided locale.
+      *
+      * @param locale
+      *   the locale to be used by the parser
+      * @return
+      *   a content parser for parsing text content as a `DateTime` using `locale` as the locale.
+      */
+    def withLocale(locale: java.util.Locale): String => DateTime = formatter.withLocale(locale).parseDateTime(_)
   }
 
   /** A content parser with extra options for the retrieval of the first match of a regex.

--- a/core/src/test/resources/test2.html
+++ b/core/src/test/resources/test2.html
@@ -64,6 +64,9 @@
             </table>
         </section>
     </div>
+    <div id="locale">
+      <span id="dutchdate">okt. 1, 2022 15:22:10 PDT</span>
+    </div>
 
     <div id="footer">
         <span>No copyright 2014</span>

--- a/core/src/test/scala/net/ruippeixotog/scalascraper/dsl/DSLExtractingSpec.scala
+++ b/core/src/test/scala/net/ruippeixotog/scalascraper/dsl/DSLExtractingSpec.scala
@@ -129,6 +129,15 @@ class DSLExtractingSpec extends Specification with BrowserHelper {
         // when there is time zone in the string to be parsed, the datetime is just changed to the provided time zone
         doc >> extractor("#datefull", stext, asDateTime("yyyy-MM-dd'T'HH:mm:ssZ").withZone(customTz)) mustEqual
           "2014-10-26T12:30:05Z".toDateTime.withZone(customTz)
+
+        // when there is locale provided, it is used
+        val dutch = java.util.Locale.forLanguageTag("nl")
+        (doc >> extractor(
+          "#dutchdate",
+          stext,
+          asDateTime("MMM dd, yyyy HH:mm:ss zzz").withLocale(dutch)
+        )).toString mustEqual
+          "2022-10-01T15:22:10.000-07:00"
       }
 
       "allow immediate parsing with a regex after extraction" in {


### PR DESCRIPTION
It provides localized datetime parsers in the extraction API similar to the handling of local time zones.

A test case is also provided. The pattern and example comes from ruippeixotog/ebay-snipe-server #7.